### PR TITLE
Handle duplicate keys in toMap method in Maps.cs

### DIFF
--- a/Mammoth/Couscous/mammoth/internal/util/Maps.cs
+++ b/Mammoth/Couscous/mammoth/internal/util/Maps.cs
@@ -36,7 +36,8 @@ namespace Mammoth.Couscous.org.zwobble.mammoth.@internal.util
         internal static Map<K, V> toMap<T, K, V>(Iterable<T> iterable, Function<T, Map__Entry<K, V>> function) {
             var dictionary = FromJava.IterableToEnumerable(iterable)
                 .Select(function.apply)
-                .ToDictionary(entry => entry.getKey(), entry => entry.getValue());
+                .GroupBy(entry => entry.getKey())
+                .ToDictionary(group => group.Key, group => group.First().getValue());
             return ToJava.DictionaryToMap(dictionary);
             
         }


### PR DESCRIPTION
Updated the toMap method to handle cases with duplicate keys in the input iterable. Previously, using ToDictionary directly would throw an exception if there were duplicate keys. The new implementation groups entries by their keys using GroupBy and converts the groups to a dictionary, taking the first value for each key. This ensures the method can handle duplicate keys gracefully by keeping only the first occurrence of each key.

In general, pull requests are not currently accepted.

Please instead submit an issue if you find a bug or would like to request a feature.
